### PR TITLE
fix href not including path

### DIFF
--- a/lib/assets/webpage/html/epubView.js
+++ b/lib/assets/webpage/html/epubView.js
@@ -227,9 +227,10 @@ function getCurrentLocation() {
 var parseChapters = function (toc) {
   var chapters = [];
   toc.forEach(function (chapter) {
+    const matchedSpine = book.spine.items.find(item => item.href.includes(chapter.href));
     chapters.push({
       title: chapter.label,
-      href: chapter.href,
+      href: matchedSpine ? matchedSpine.href : chapter.href,
       id: chapter.id,
       subitems: parseChapters(chapter.subitems)
     });


### PR DESCRIPTION
fix href not including path
example:
xhtml/chapter1.xhtml

href will be returned chapter1.html instead xhtml/cahpter1.xhtml